### PR TITLE
add CODE_OF_CONDUCT.md based on Contributor Covenant v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,114 @@
+# 📜 Code of Conduct
+
+## Our Pledge
+
+We as contributors, maintainers, and participants of the **archpkg-helper** project pledge to make participation in our community a harassment-free experience for everyone, regardless of:
+
+- Age
+- Body size
+- Visible or invisible disability
+- Ethnicity
+- Sex characteristics
+- Gender identity and expression
+- Level of experience
+- Education
+- Socio-economic status
+- Nationality
+- Personal appearance
+- Race
+- Religion
+- Sexual identity and orientation
+
+We are committed to fostering an open, inclusive, and respectful environment.
+
+---
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+✅ Using welcoming and inclusive language  
+✅ Being respectful of differing viewpoints and experiences  
+✅ Accepting constructive feedback graciously  
+✅ Focusing on what is best for the community  
+✅ Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+🚫 Harassment, trolling, or abusive language  
+🚫 Discriminatory or derogatory comments  
+🚫 Public or private sexual harassment  
+🚫 Publishing others' private information without consent  
+🚫 Sustained disruptive behavior that disturbs the community
+
+---
+## Our Responsibilities
+
+Project maintainers are responsible for:
+- Clarifying and enforcing a standards of acceptable behavior
+- Taking appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+They have the right and responsibility to **remove**, **edit**, or **reject comments**, commits, issues, pull requests, or other contributions that are not aligned with this Code of Conduct.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including:
+- GitHub repositories
+- Pull requests and issues
+- Discussions and comments
+- Community communication channels (e.g., Discord, Slack, etc.)
+
+---
+## Enforcement
+
+If you witness or experience any behavior that violates this Code of Conduct, please report it by contacting the maintainers at:
+
+📧 **Contact Email**: [maintainer@example.com](to be updated by maintainers) 
+
+🛠️ You may also use GitHub’s built-in **report** feature if needed.
+
+All reports will be reviewed and investigated promptly and fairly. We are committed to protecting the privacy and safety of reporters.
+
+---
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [here](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder]( https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the 
+- FAQ available at [FAQ](https://www.contributor-covenant.org/faq) 
+- Translations are available at [translations](https://www.contributor-covenant.org/translations).
+


### PR DESCRIPTION
## 📜 Add CODE_OF_CONDUCT.md

### Description
This PR adds a `CODE_OF_CONDUCT.md` file based on the Contributor Covenant v2.1, customized for **archpkg-helper**.  
It defines clear guidelines for respectful communication, inclusive collaboration, and reporting unacceptable behavior.

### Why?
- Helps maintain a positive and professional community  
- Aligns with open-source best practices  
- Provides contributors with clear expectations  
- 
### Closed #5 

If there are any updates, corrections, or revisions needed for this Code of Conduct, please feel free to suggest them. I am happy to make any necessary adjustments to ensure it aligns perfectly with the project’s standards and expectations.
