### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Description
+<!-- A clear and concise description of what this PR does. -->
+
+## Related Issue
+<!-- If this PR addresses an issue, please include the issue number. -->
+Fixes #<issue_number>
+
+## Changes Made
+<!-- List the changes made in this PR. -->
+- [ ] Updated ...
+- [ ] Added ...
+- [ ] Removed ...
+
+## Screenshots or GIFs (if applicable)
+<!-- Add visual changes to better communicate your changes. -->
+
+## Checklist
+
+- [ ] Code is formatted with the project’s Prettier config provided in `.prettierrc` (if present).
+- [ ] Only the necessary files are modified; no unrelated changes are included.
+- [ ] Follows clean code principles (readable, maintainable, minimal duplication).
+- [ ] All changes are clearly documented.
+- [ ] Code has been tested (manual/automated) and verified against edge cases.
+- [ ] No breaking changes are introduced to existing functionality.
+- [ ] All new and existing tests passed (if tests exist).
+
+## Additional Notes
+<!-- Add any other relevant information or context, e.g., migration steps, config changes, or follow-up tasks. -->


### PR DESCRIPTION
## Description
Add a standardized Pull Request template to ensure PRs include a description, related issue reference, change list, screenshots (if applicable), and a checklist. This helps maintainers review submissions faster and keeps contributions consistent.

## Related Issue
Fixes #43 

## Changes Made
- Added `.github/PULL_REQUEST_TEMPLATE.md`

## Checklist
- [x] Template added under `.github/`
- [x] Content follows repo's PR format

## Additional Notes
This is a documentation-only change and does not affect runtime code.
